### PR TITLE
Don't specify development dependencies as "dependencies" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,6 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
-    "karma": "^0.12.31",
-    "gulp": "^3.8.11",
-    "karma-phantomjs-launcher": "^0.1.4",
-    "jasmine-core": "^2.2.0",
-    "karma-jasmine": "^0.3.5"
-  },
   "devDependencies": {
     "bower": "^1.3.12",
     "gulp": "^3.8.11",


### PR DESCRIPTION
Otherwise, when projects that pull in this library run `npm install --production`, they will be forced to pull down dependencies that are not needed at runtime.
