### PR TITLE
Add aria-label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bower_components
 node_modules
+
+*.log

--- a/.jscsrc
+++ b/.jscsrc
@@ -91,7 +91,7 @@
   "maximumLineLength": 120,
   "requireCapitalizedConstructors": true,
   "disallowYodaConditions": true,
-  "validateJSDoc": {
+  "jsDoc": {
     "checkParamNames": true,
     "checkRedundantParams": true,
     "requireParamTypes": true

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,11 +1,11 @@
 var gulp = require('gulp'),
-    karma = require('karma').server;
+    Server = require('karma').Server;
 
 gulp.task('test', function (done) {
-  karma.start({
-    configFile: __dirname + '/karma.conf.js',
-    singleRun: true
-  }, done);
+  new Server({
+   configFile: __dirname + '/karma.conf.js',
+   singleRun: true
+ }, done).start();
 });
 
 gulp.task('default', ['test']);

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This should all look very familiar, the only difference is `-once` in the direct
 
 ## Instruction for contributors
 ```
+npm install -g jshint
+npm install -g jscs
 npm install
 npm run pretest
 npm test

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 `angular-translate-once` is an extension of [`angular-translate`](https://github.com/angular-translate/angular-translate) by introducing one-time bindings for static content.
 
-By default, all of your translations beocme part of the digest cycle and bloat your application's [`$watch` list](https://docs.angularjs.org/api/ng/type/$rootScope.Scope#$watch). You don't really need to observe any changes for things like
+By default, all of your translations become part of the digest cycle and bloat your application's [`$watch` list](https://docs.angularjs.org/api/ng/type/$rootScope.Scope#$watch). You don't really need to observe any changes for things like
 
 - form labels
 - input placeholders

--- a/README.md
+++ b/README.md
@@ -39,6 +39,5 @@ npm install -g jscs
 npm install -g gulp
 npm install
 bower install
-npm run pretest
 npm test
 ```

--- a/README.md
+++ b/README.md
@@ -35,4 +35,6 @@ This should all look very familiar, the only difference is `-once` in the direct
 ## Instruction for contributors
 ```
 npm install
+npm run pretest
+npm test
 ```

--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ These things really only need to bind once. If you're looking to trim any excess
 ---
 
 This should all look very familiar, the only difference is `-once` in the directive name, and that the translation will be applied as soon as the directive is linked.
+
+## Instruction for contributors
+```
+npm install
+```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ This should all look very familiar, the only difference is `-once` in the direct
 ```
 npm install -g jshint
 npm install -g jscs
+npm install -g gulp
 npm install
+bower install
 npm run pretest
 npm test
 ```

--- a/bower.json
+++ b/bower.json
@@ -8,12 +8,12 @@
   "main": "src/translate-once.js",
   "license": "MIT",
   "dependencies": {
-    "angular-translate": "*"
+    "angular-translate": "~2.9.0"
   },
   "devDependencies": {
-    "angular-mocks": "~1.3.15",
-    "angular-translate": "~2.6.1",
-    "angular": "~1.3.15",
-    "jquery": "~2.1.3"
+    "angular-mocks": "~1.4.9",
+    "angular-translate": "~2.9.0",
+    "angular": "~1.4.9",
+    "jquery": "~2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "test": "test"
   },
   "devDependencies": {
-    "bower": "^1.3.12",
-    "gulp": "^3.8.11",
-    "jasmine-core": "^2.2.0",
-    "jscs": "^1.12.0",
-    "jshint": "^2.6.3",
-    "karma": "^0.12.31",
-    "karma-jasmine": "^0.3.5",
-    "karma-phantomjs-launcher": "^0.1.4"
+    "bower": "^1.7.7",
+    "gulp": "^3.9.0",
+    "jasmine-core": "^2.4.1",
+    "jscs": "^2.9.0",
+    "jshint": "^2.9.1",
+    "karma": "^0.13.19",
+    "karma-jasmine": "^0.3.6",
+    "karma-phantomjs-launcher": "^1.0.0"
   },
   "scripts": {
     "test": "gulp test",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "jshint": "^2.9.1",
     "karma": "^0.13.19",
     "karma-jasmine": "^0.3.6",
-    "karma-phantomjs-launcher": "^1.0.0"
+    "karma-phantomjs-launcher": "^1.0.0",
+    "phantomjs-prebuilt": "^2.1.3"
   },
   "scripts": {
     "test": "gulp test",

--- a/src/translate-once.js
+++ b/src/translate-once.js
@@ -7,7 +7,23 @@
       createDirective;
 
   getNamedDirectiveFromAttribute = function (attribute) {
-    return DIRECTIVE_NAME + attribute.charAt(0).toUpperCase() + attribute.slice(1);
+    // return DIRECTIVE_NAME + attribute.charAt(0).toUpperCase() + attribute.slice(1);
+
+    var toCamelCase = function (attr) {
+      return attr.split('-')
+        .map(function (word) {
+          return word.charAt(0).toUpperCase() + word.slice(1);
+        })
+        .join('');
+    };
+
+    // var attributeNameCamelCase = attribute.split('-')
+    //   .map(function (word) {
+    //     return word.charAt(0).toUpperCase() + word.slice(1);
+    //   })
+    //   .join('');
+
+    return DIRECTIVE_NAME + toCamelCase(attribute);
   };
 
   /**

--- a/src/translate-once.js
+++ b/src/translate-once.js
@@ -10,18 +10,12 @@
     return DIRECTIVE_NAME + attribute.charAt(0).toUpperCase() + attribute.slice(1);
   };
 
-  createDirective = function (attribute) {
-    var namedDirective = getNamedDirectiveFromAttribute(attribute);
-    angular.module(MODULE_NAME).directive(namedDirective, ['$parse', '$translate',
-    angular.bind(undefined, TranslateOnceAttributeDirective, attribute)]);
-  };
-
   /**
    * Translate Once Attributes
    * Translate a key once for a given attribute
    * <a translate-once-title="TRANSLATION_TITLE"><a>
    */
-  function TranslateOnceAttributeDirective (attribute, $parse, $translate) {
+  var TranslateOnceAttributeDirective = function (attribute, $parse, $translate) {
     var namedDirective = getNamedDirectiveFromAttribute(attribute);
     return {
       restrict: 'A',
@@ -39,7 +33,13 @@
         });
       }
     };
-  }
+  };
+
+  createDirective = function (attribute) {
+    var namedDirective = getNamedDirectiveFromAttribute(attribute);
+    angular.module(MODULE_NAME).directive(namedDirective, ['$parse', '$translate',
+    angular.bind(undefined, TranslateOnceAttributeDirective, attribute)]);
+  };
 
   /**
    * Translate Once

--- a/src/translate-once.js
+++ b/src/translate-once.js
@@ -7,8 +7,6 @@
       createDirective;
 
   getNamedDirectiveFromAttribute = function (attribute) {
-    // return DIRECTIVE_NAME + attribute.charAt(0).toUpperCase() + attribute.slice(1);
-
     var toCamelCase = function (attr) {
       return attr.split('-')
         .map(function (word) {
@@ -16,12 +14,6 @@
         })
         .join('');
     };
-
-    // var attributeNameCamelCase = attribute.split('-')
-    //   .map(function (word) {
-    //     return word.charAt(0).toUpperCase() + word.slice(1);
-    //   })
-    //   .join('');
 
     return DIRECTIVE_NAME + toCamelCase(attribute);
   };

--- a/src/translate-once.js
+++ b/src/translate-once.js
@@ -2,7 +2,7 @@
   'use strict';
   var MODULE_NAME = 'pascalprecht.translate',
       DIRECTIVE_NAME = 'translateOnce',
-      ATTRS = ['value', 'title', 'alt', 'placeholder'],
+      ATTRS = ['value', 'title', 'alt', 'placeholder', 'aria-label'],
       getNamedDirectiveFromAttribute,
       createDirective;
 

--- a/test/unit/translate-once.spec.js
+++ b/test/unit/translate-once.spec.js
@@ -4,7 +4,7 @@ describe('pascalprecht.translate', function () {
   describe('$translateOnce', function () {
     var $compile,
         $rootScope,
-        elementAttributes = ['placeholder', 'title', 'alt', 'value'],
+        elementAttributes = ['placeholder', 'title', 'alt', 'value', 'aria-label'],
         translations = {
           'FOO': 'foo',
           'BAR': 'bar',

--- a/test/unit/translate-once.spec.js
+++ b/test/unit/translate-once.spec.js
@@ -4,7 +4,7 @@ describe('pascalprecht.translate', function () {
   describe('$translateOnce', function () {
     var $compile,
         $rootScope,
-        elementAttributes = ['placeholder', 'title', 'alt', 'value', 'aria-label'],
+        elementAttributes = ['placeholder', 'title', 'alt', 'value'],
         translations = {
           'FOO': 'foo',
           'BAR': 'bar',


### PR DESCRIPTION
Add aria-label attribute

> The aria-label attribute is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use aria-labelledby instead.
